### PR TITLE
Add extensive documentation

### DIFF
--- a/gerador_amostras_magnetostriccao.py
+++ b/gerador_amostras_magnetostriccao.py
@@ -1,3 +1,5 @@
+"""Gerador de amostras sintéticas de magnetostricção."""
+
 import os
 import numpy as np
 import random
@@ -18,6 +20,8 @@ DIR_IRS = "./impulse_responses"
 DIR_EQ_CURVES = "./eq_curvas_microfone"
 
 def gerar_sinal_base(label, sem_ruido=False):
+    """Gera sinal fundamental com harmônicas simulando magnetostricção."""
+
     base_freq = 60 + np.random.uniform(-2, 2)  # Pequena variação de frequência fundamental
     harmonicas = list(range(2, 16))
     sinal = np.zeros_like(t)
@@ -47,12 +51,16 @@ def gerar_sinal_base(label, sem_ruido=False):
     return sinal
 
 def carregar_audio_pydub(path):
+    """Carrega áudio usando pydub e converte para numpy."""
+
     audio = AudioSegment.from_file(path).set_channels(1).set_frame_rate(fs)
     arr = np.array(audio.get_array_of_samples()).astype(np.float32) / 32768.0
     dur = len(arr) / fs
     return arr, dur
 
 def aplicar_ruido_real(sinal, nivel_ruido=1.5):
+    """Combina o sinal base com um ruído externo real."""
+
     arquivos_ruido = glob(os.path.join(DIR_RUIDOS, "*.wav")) + glob(os.path.join(DIR_RUIDOS, "*.mp3"))
     if not arquivos_ruido:
         return sinal, "sem_ruido"
@@ -66,6 +74,8 @@ def aplicar_ruido_real(sinal, nivel_ruido=1.5):
     return sinal, os.path.splitext(os.path.basename(arquivo))[0]
 
 def aplicar_convolucao_IR(sinal):
+    """Aplica resposta impulsiva para simular ambiente."""
+
     arquivos_ir = glob(os.path.join(DIR_IRS, "*.wav"))
     if not arquivos_ir:
         return sinal
@@ -73,6 +83,8 @@ def aplicar_convolucao_IR(sinal):
     return fftconvolve(sinal, ir, mode='same')
 
 def aplicar_equalizacao(sinal):
+    """Aplica curva de equalização de microfone ao sinal."""
+
     arquivos_eq = glob(os.path.join(DIR_EQ_CURVES, "*.wav"))
     if not arquivos_eq:
         return sinal
@@ -81,6 +93,8 @@ def aplicar_equalizacao(sinal):
     return sinal * curva_eq
 
 def salvar_wav(sinal, path):
+    """Salva array numpy como arquivo WAV normalizado."""
+
     wav_data = np.int16(sinal / np.max(np.abs(sinal)) * 32767)
     sf.write(path, wav_data, fs)
 
@@ -123,6 +137,8 @@ def gerar_amostras_fatorial(destino, n_sinais=20, nivel_ruido=1.5):
 # Função original mantida para compatibilidade e geração padrão
 
 def gerar_amostras(destino, total, proporcao_treino, proporcao_ruido=0.3, nivel_ruido=1.5):
+    """Gera dataset de treino/teste com opção de ruído externo."""
+
     treino_dir = os.path.join(destino, "train")
     teste_dir = os.path.join(destino, "test")
     for d in [treino_dir, teste_dir]:
@@ -169,6 +185,8 @@ def gerar_amostras(destino, total, proporcao_treino, proporcao_ruido=0.3, nivel_
 # Exemplo: para 20 sinais por label e todos os ruídos em ./ruidos_externos
 # O diretório de saída será ./samples_fatorial
 def gerar_sinal_base_com_duracao(n_amostras, label=None):
+    """Versão de ``gerar_sinal_base`` que respeita um tamanho arbitrário."""
+
     base_freq = 60 + np.random.uniform(-2, 2)
     harmonicas = list(range(2, 16))
     t_local = np.linspace(0, n_amostras / fs, n_amostras, endpoint=False)

--- a/h5_to_stm32_tinyml.py
+++ b/h5_to_stm32_tinyml.py
@@ -1,3 +1,5 @@
+"""Ferramenta para converter modelos Keras para formatos TinyML."""
+
 import argparse
 import os
 import sys
@@ -9,6 +11,8 @@ except ImportError:
     np = None
 
 def convert_h5_to_tflite(h5_path, tflite_path):
+    """Converte arquivo ``.h5`` em modelo TFLite."""
+
     model = tf.keras.models.load_model(h5_path)
     converter = tf.lite.TFLiteConverter.from_keras_model(model)
     tflite_model = converter.convert()
@@ -16,7 +20,9 @@ def convert_h5_to_tflite(h5_path, tflite_path):
         f.write(tflite_model)
     print(f"TFLite model saved to {tflite_path}")
 
-def tflite_to_c_array(tflite_path, c_path, var_name="model_tflite"): 
+def tflite_to_c_array(tflite_path, c_path, var_name="model_tflite"):
+    """Converte arquivo TFLite em array C para uso em microcontroladores."""
+
     with open(tflite_path, "rb") as f:
         tflite_bytes = f.read()
     with open(c_path, "w") as f:
@@ -32,6 +38,8 @@ def tflite_to_c_array(tflite_path, c_path, var_name="model_tflite"):
     print(f"C array saved to {c_path}")
 
 def main():
+    """Função principal do script de conversão."""
+
     parser = argparse.ArgumentParser(description="Converte arquivo .h5 para formato STM32 TinyML (TFLite e C array)")
     parser.add_argument("input_h5", help="Caminho para o arquivo .h5 do modelo treinado")
     parser.add_argument("--tflite", help="Caminho de saída do arquivo .tflite", default=None)

--- a/simulador/__main__.py
+++ b/simulador/__main__.py
@@ -1,3 +1,5 @@
+"""Ponto de entrada para a aplicação gráfica de análise de magnetostricção."""
+
 import sys
 import argparse
 import os

--- a/simulador/analysis_thread.py
+++ b/simulador/analysis_thread.py
@@ -1,3 +1,10 @@
+"""Rotina de análise de áudio em tempo real.
+
+Este módulo define uma QThread responsável por capturar som do microfone,
+processá-lo e emitir resultados intermediários (espectrograma, Mel bands, FFT
+e classificação) sem bloquear a interface gráfica.
+"""
+
 # analysis_thread.py - Thread para análise de arquivos de áudio
 import time
 
@@ -32,10 +39,23 @@ class FileAnalysisThread(QThread):
     class_ready = pyqtSignal(int)
 
     def __init__(self, b, a, sr, duration, model, max_time):
-        super().__init__()
+        """Inicializa a thread de análise de áudio.
 
-        # Lista de caminhos para arquivos de teste
-        # Não armazena lista de arquivos, usa entrada de áudio ao vivo
+        Parameters
+        ----------
+        b, a : ndarray
+            Coeficientes do filtro Butterworth usado no pré-processamento.
+        sr : int
+            Taxa de amostragem utilizada na captura.
+        duration : float
+            Duração máxima de cada captura em segundos.
+        model : keras.Model
+            Modelo carregado responsável pela classificação.
+        max_time : int
+            Número de quadros esperados pelo modelo (eixo temporal dos MFCCs).
+        """
+
+        super().__init__()
 
         # Coeficientes do filtro passa-baixo (Butterworth)
         self.b = b

--- a/simulador/analyzer_app.py
+++ b/simulador/analyzer_app.py
@@ -1040,7 +1040,11 @@ class AnalyzerApp(QMainWindow):
 
 
 class StatsDialog(QDialog):
+    """Janela para exibição detalhada de métricas de processamento."""
+
     def __init__(self, parent, current_stats, proposed_metrics):
+        """Constrói o diálogo com estatísticas atuais e propostas."""
+
         super().__init__(parent)
         self.setWindowTitle('Detalhes de Estatísticas')
         layout = QVBoxLayout(self)

--- a/simulador/classification_thread.py
+++ b/simulador/classification_thread.py
@@ -6,7 +6,19 @@ import scipy.signal
 import numpy as np
 
 
+"""Thread de classificação de arquivos de áudio."""
+
+
 class ClassificationThread(QThread):
+    """Executa classificação de forma assíncrona.
+
+    A thread percorre todos os arquivos recebidos, realiza o pré-processamento
+    (filtro, extração de espectrograma/MFCC e FFT) e, em seguida, envia os
+    resultados de inferência para a GUI através de sinais.  As métricas de
+    tempo de carregamento, pré-processamento e inferência são emitidas para
+    monitoramento de desempenho.
+    """
+
     progress = pyqtSignal(int, int)
     spec_ready = pyqtSignal(np.ndarray, np.ndarray)
     mel_ready = pyqtSignal(np.ndarray)
@@ -18,6 +30,27 @@ class ClassificationThread(QThread):
     detailed_metrics = pyqtSignal(float, float, float)
 
     def __init__(self, test_files, model, b, a, sr, duration, n_mfcc, fmax):
+        """Configura a thread de classificação.
+
+        Parâmetros
+        ----------
+        test_files : list[str]
+            Lista de caminhos para os arquivos de teste.
+        model : keras.Model
+            Modelo já carregado utilizado na inferência.
+        b, a : ndarray
+            Coeficientes do filtro Butterworth utilizado para pré-processar o
+            áudio.
+        sr : int
+            Taxa de amostragem dos arquivos.
+        duration : int or float
+            Duração máxima lida de cada arquivo (segundos).
+        n_mfcc : int
+            Número de coeficientes MFCC extraídos.
+        fmax : int
+            Frequência máxima considerada na análise.
+        """
+
         super().__init__()
         self.test_files = test_files
         self.model = model
@@ -30,6 +63,8 @@ class ClassificationThread(QThread):
         self._running = True
 
     def run(self):
+        """Processa cada arquivo de teste e envia resultados via sinais."""
+
         total_files = len(self.test_files)
         report_path = os.path.join('relatorio_classificacao.csv')
 
@@ -125,4 +160,6 @@ class ClassificationThread(QThread):
         self.finished.emit()
 
     def stop(self):
+        """Solicita o encerramento da thread."""
+
         self._running = False


### PR DESCRIPTION
## Summary
- document classification thread internals
- clarify analysis thread usage
- add docstrings to sample generator and conversion scripts
- describe StatsDialog widget and module entry point

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6861d73dd7f4832e9b9f7aa11107388b